### PR TITLE
expose `objs` argument in `write_lci_csv` to allow filtering database…

### DIFF
--- a/bw2io/export/csv.py
+++ b/bw2io/export/csv.py
@@ -229,7 +229,7 @@ class CSVFormatter(object):
         return result
 
 
-def write_lci_csv(database_name, sections=None):
+def write_lci_csv(database_name, objs=None, sections=None):
     """Export database `database_name` to a CSV file.
 
     Not all data can be exported. The following constraints apply:
@@ -240,7 +240,7 @@ def write_lci_csv(database_name, sections=None):
     Returns the filepath of the exported file.
 
     """
-    data = CSVFormatter(database_name).get_formatted_data(sections)
+    data = CSVFormatter(database_name, objs).get_formatted_data(sections)
 
     safe_name = safe_filename(database_name, False)
     filepath = os.path.join(projects.output_dir, "lci-" + safe_name + ".csv")


### PR DESCRIPTION
Expose `objs` argument in `write_lci_csv` to allow filtering database activities before export (requested in #70). This also harmonizes the export signature as the argument is already exposed in `write_lci_excel`.