### PR TITLE
Harmonize SimaPro - ecoinvent 3.4 mapping process

### DIFF
--- a/bw2io/data/__init__.py
+++ b/bw2io/data/__init__.py
@@ -216,6 +216,8 @@ def convert_simapro_ecoinvent_3_migration_data():
         ("Mapping", "3.1"),
         ("Mapping 3.2", "3.2"),
         ("Mapping 3.3", "3.3"),
+        ("Mapping 3.4", "3.4"),
+        ("Mapping 3.5", "3.5"),
     )
 
     for ws_name, version in VERSIONS:


### PR DESCRIPTION
- Include data in SimaPro - ecoinvent - technosphere.xslx
- Include in convert_simapro_ecoinvent_3_migration_data to convert xlsx
  in properly formatted gzip
- No modifications to list of core migrations, as it was already there
Notes: 
- only looks at technosphere mappings.
- expects https://github.com/brightway-lca/brightway2-io/pull/80 to be included first.
