### PR TITLE
Performance improvement for reading cells with openpyxl

### DIFF
--- a/bw2io/extractors/excel.py
+++ b/bw2io/extractors/excel.py
@@ -23,8 +23,8 @@ class ExcelExtractor(object):
         _ = lambda x: x.strip() if (strip and hasattr(x, "strip")) else x
         return [
             [
-                _(get_cell_value_handle_error(ws.cell(row=row + 1, column=col + 1)))
-                for col in range(ws.max_column)
+                _(get_cell_value_handle_error(cell))
+                for colidx, cell in enumerate(row)
             ]
-            for row in range(ws.max_row)
+            for rowidx, row in enumerate(ws.rows)
         ]


### PR DESCRIPTION
Repetitive call of function ws.cell is time consuming according to https://blog.dchidell.com/2019/06/24/openpyxl-poor-performance-optimisation/. Proposed solution was taken from there as well reducing the reading time of the impact categories in repo bw_recipe_2016 from 5+ hours to a few minutes.