### PR TITLE
Specify filepath for ecoinvent LCIA methods file.

### DIFF
--- a/bw2io/__init__.py
+++ b/bw2io/__init__.py
@@ -106,24 +106,24 @@ def create_default_biosphere3(overwrite=False):
     eb.write_database(overwrite=overwrite)
 
 
-def create_default_lcia_methods(overwrite=False, rationalize_method_names=False):
+def create_default_lcia_methods(lcia_filepath=None, overwrite=False, rationalize_method_names=False):
     from .importers import EcoinventLCIAImporter
 
-    ei = EcoinventLCIAImporter()
+    ei = EcoinventLCIAImporter(filename=lcia_filepath)
     if rationalize_method_names:
         ei.add_rationalize_method_names_strategy()
     ei.apply_strategies()
     ei.write_methods(overwrite=overwrite)
 
 
-def bw2setup():
+def bw2setup(lcia_filepath=None):
     if "biosphere3" in databases:
         print("Biosphere database already present!!! No setup is needed")
         return
     print("Creating default biosphere\n")
     create_default_biosphere3()
     print("Creating default LCIA methods\n")
-    create_default_lcia_methods()
+    create_default_lcia_methods(lcia_filepath=lcia_filepath)
     print("Creating core data migrations\n")
     create_core_migrations()
 

--- a/bw2io/data/__init__.py
+++ b/bw2io/data/__init__.py
@@ -341,7 +341,7 @@ add_ecoinvent_38_biosphere_flows = partial(
 )
 
 
-def convert_lcia_methods_data():
+def convert_lcia_methods_data(filename):
     csv_file = csv.reader(
         open(dirpath / "lcia" / "categoryUUIDs.csv", encoding="latin-1"), delimiter=";"
     )
@@ -355,8 +355,15 @@ def convert_lcia_methods_data():
         for line in csv_file
     ]
 
-    filename = "LCIA_Implementation_3.8.xlsx"
-    sheet = get_sheet(dirpath / "lcia" / filename, "CFs")
+    if filename:
+        filename = str(filename)
+    else:
+        filename = str(dirpath / "lcia" / "LCIA_Implementation_3.8.xlsx")
+
+    if not Path(filename).is_file():
+        raise FileNotFoundError(f"The LCIA methods file could not be located at {filename}.")
+
+    sheet = get_sheet(filename, "CFs")
 
     def process_row(row):
         data = [cell.value for i, cell in zip(range(8), row)]

--- a/bw2io/importers/ecoinvent_lcia.py
+++ b/bw2io/importers/ecoinvent_lcia.py
@@ -17,7 +17,7 @@ from .base_lcia import LCIAImporter
 
 
 class EcoinventLCIAImporter(LCIAImporter):
-    def __init__(self):
+    def __init__(self, filename):
         # Needs to define strategies in ``__init__`` because
         # ``config.biosphere`` is dynamic
         self.strategies = [
@@ -32,7 +32,7 @@ class EcoinventLCIAImporter(LCIAImporter):
             ),
         ]
         self.applied_strategies = []
-        self.csv_data, self.cf_data, self.units, self.file = convert_lcia_methods_data()
+        self.csv_data, self.cf_data, self.units, self.file = convert_lcia_methods_data(filename)
         self.separate_methods()
 
     def add_rationalize_method_names_strategy(self):


### PR DESCRIPTION
In case the ecoinvent LCIA file is no longer present within the library data folder, the user can specify a file path to `bw.bw2setup(lcia_filepath="some_filepath.xlsx")`.