### PR TITLE
Fixed import of SimaPro data with lognormal uncertainty and 1 as sigma

### DIFF
--- a/bw2io/extractors/simapro_csv.py
+++ b/bw2io/extractors/simapro_csv.py
@@ -232,7 +232,7 @@ class SimaProCSVExtractor(object):
 
     @classmethod
     def invalid_uncertainty_data(cls, amount, kind, field1, field2, field3):
-        if kind == "Lognormal" and (not amount or field1 == "0"):
+        if kind == "Lognormal" and (not amount or field1 == "0" or field1 == "1"):
             return True
 
     @classmethod

--- a/tests/fixtures/simapro/process_with_invalid_lognormal_scale.csv
+++ b/tests/fixtures/simapro/process_with_invalid_lognormal_scale.csv
@@ -1,0 +1,128 @@
+{SimaPro 9.3.0.3}
+{processes}
+{Date: 30/09/2022}
+{Time: 08:35:52}
+{Project: Dummy project}
+{CSV Format version: 9.0.0}
+{CSV separator: Semicolon}
+{Decimal separator: .}
+{Date separator: /}
+{Short date format: dd/MM/yyyy}
+{Export platform IDs: No}
+{Skip empty fields: No}
+{Convert expressions to constants: Yes}
+{Selection: Current (1)}
+{Related objects (system descriptions, substances, units, etc.): Yes}
+{Include sub product stages and processes: Yes}
+{Open project: 'Dummy project'}
+{Library 'Methods'}
+
+Process
+
+Category type
+material
+
+Process identifier
+gfhjjXXX000079938200031
+
+Type
+
+
+Process name
+
+
+Status
+
+
+Time period
+Unspecified
+
+Geography
+Unspecified
+
+Technology
+Unspecified
+
+Representativeness
+Unspecified
+
+Multiple output allocation
+Unspecified
+
+Substitution allocation
+Unspecified
+
+Cut off rules
+Unspecified
+
+Capital goods
+Unspecified
+
+Boundary with nature
+Unspecified
+
+Infrastructure
+No
+
+Date
+30/09/2022
+
+Record
+
+
+Generator
+
+
+External documents
+
+
+Literature references
+
+
+Collection method
+
+
+Data treatment
+
+
+Verification
+
+
+Comment
+
+
+Allocation rules
+
+
+System description
+;
+
+Products
+Process with invalid lognormal scale;kg;1;100;not defined;_Test;
+
+Avoided products
+
+Resources
+Aluminium;;kg;1;Lognormal;1;0;0;
+
+Materials/fuels
+
+Electricity/heat
+
+Emissions to air
+
+Emissions to water
+
+Emissions to soil
+
+Final waste flows
+
+Non material emissions
+
+Social issues
+
+Economic issues
+
+Waste to treatment
+
+End

--- a/tests/simapro.py
+++ b/tests/simapro.py
@@ -51,6 +51,12 @@ def test_sp_python_builtin_as_unit_name():
 
 
 @bw2test
+def test_sp_invalid_lognormal_scale():
+    sp = SimaProCSVImporter(os.path.join(SP_FIXTURES_DIR, "process_with_invalid_lognormal_scale.csv"))
+    assert sp.data[0]['exchanges'][1]['uncertainty type'] == 0
+
+
+@bw2test
 def test_damage_category_import():
     # Write the 2 item biosphere database
     database = Database("biosphere3")


### PR DESCRIPTION
If the uncertainty is lognormal and the sigma (in SimaPro) is 1, then the loc of the exchange uncertainty will be 0 which makes MC LCA crash because lognormal sigma should always be strictly positive.