### PR TITLE
raise error when empty directory given to ecospold2 importer

### DIFF
--- a/bw2io/extractors/ecospold2.py
+++ b/bw2io/extractors/ecospold2.py
@@ -73,6 +73,9 @@ class Ecospold2DataExtractor(object):
         if sys.version_info < (3, 0):
             use_mp = False
 
+        if len(filelist) == 0:
+            raise FileNotFoundError(f"No .spold files found. Please check the path and try again: {dirpath}")
+
         if use_mp:
             with multiprocessing.Pool(processes=multiprocessing.cpu_count()) as pool:
                 print("Extracting XML data from {} datasets".format(len(filelist)))


### PR DESCRIPTION
The ecospold importer should raise an error when an empty directory is given. Currently, import scripts fail with cryptic error messages somewhere down the line and it is not possible for inexperienced users to figure out where the error comes from.

Related issues:
https://github.com/brightway-lca/brightway2/issues/54
https://github.com/brightway-lca/brightway2-io/issues/97