### PR TITLE
field equality strategy and default location strategy

### DIFF
--- a/bw2io/strategies/generic.py
+++ b/bw2io/strategies/generic.py
@@ -9,6 +9,7 @@ import numpy as np
 import pprint
 
 link_iterable_by_fields = ExchangeLinker.link_iterable_by_fields
+overwrite_exchange_field_values = ExchangeLinker.overwrite_exchange_field_values_with_linked_activity_values
 
 
 def format_nonunique_key_error(obj, fields, others):

--- a/bw2io/strategies/generic.py
+++ b/bw2io/strategies/generic.py
@@ -251,3 +251,17 @@ def split_exchanges(data, filter_params, changed_attributes, allocation_factors=
                 del ds['exchanges'][index]
             ds['exchanges'].extend(to_add)
     return data
+
+
+def assign_default_location(activities, default_loc="GLO", overwrite=False):
+    """
+    Goes through the database and assigns activity locations where they are missing.
+    :param activities: iterable of dicts describing activities
+    :param default_loc: the default location to assign
+    :param overwrite: whether or not to overwrite existing location values
+    :return: modified iterable of activities
+    """
+    for act in activities:
+        if overwrite or "location" not in act:
+            act["location"] = default_loc
+    return activities

--- a/bw2io/utils.py
+++ b/bw2io/utils.py
@@ -6,6 +6,7 @@ import json
 import os
 import pprint
 import re
+from bw2data import get_activity
 
 from .errors import StrategyError, UnsupportedExchange
 
@@ -218,5 +219,21 @@ class ExchangeLinker:
         )
         return activities
 
+    @staticmethod
+    def overwrite_exchange_field_values_with_linked_activity_values(activities, fields=DEFAULT_FIELDS):
+        """
+        This function goes through all exchanges and copies `fields` values from the linked activity to the exchange.
+        This might be helpful after linking "soft-matched" fields, such as `categories`, where a string "('air',)"
+        is treated as identical to a tuple ('air',) etc.
+        """
+        for act in activities:
+            for ex in act.get("exchanges", []):
+                if "input" not in ex:
+                    continue
+                in_act = get_activity(ex["input"])
+                for field in fields:
+                    if field in in_act:
+                        ex[field] = in_act[field]
+        return activities
 
 activity_hash = ExchangeLinker.activity_hash


### PR DESCRIPTION
This PR adds two new generic strategies:

1) `bw2io.strategies.generic.overwrite_exchange_field_values`: The new `ExchangeLinker` class introduced in f5c9d28 allows "soft-matches", i.e. an exchange field `exchange["categories"] = "(air,)"` will be identified as matching an activity `activity["categories"] = ("air",)`. However, this means that the exchange data in the database contains a string instead of a tuple. This might be undesirable in some use cases. The new strategy fixes this by going through all exchanges and overwriting their fields with values from the linked activities.

2) `bw2io.strategies.generic.assign_default_location`: Brightway allows defining activities without a location field. However, tools like the Activity Browser Sankey Diagram expect a location field and will break if there isn't any. This strategy goes through all activities and applies a `default_loc` where locations are missing.