### PR TITLE
express union compatible py3.8

### DIFF
--- a/bw2io/remote.py
+++ b/bw2io/remote.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Optional
+from typing import Optional,Union
 
 import bw2data as bd
 import requests
@@ -44,7 +44,7 @@ def install_project(
     projects_config: Optional[dict] = get_projects(),
     url: Optional[str] = "https://files.brightway.dev/",
     overwrite_existing: Optional[bool] = False,
-    __recursive: bool | None = False
+    __recursive: Union[bool,None] = False
 ):
     """
     Install an existing Brightway project archive.


### PR DESCRIPTION
This pull request is associated with this issue https://github.com/brightway-lca/brightway2-io/issues/198

Union is expressed using syntactic sugar of python 3.10, I agree it looks nicer, but then it forces users to use python 3.10, while sometimes we have to work on environments with older versions of python. 

I would rather use new features of newer python versions when really needed. 