### PR TITLE
fix unsupported operand

### DIFF
--- a/bw2io/data/__init__.py
+++ b/bw2io/data/__init__.py
@@ -17,7 +17,8 @@ dirpath = Path(__file__).parent.resolve()
 
 
 def write_json_file(data, name):
-    with open(dirpath / name + ".json", "w", encoding="utf-8") as fp:
+    filename = name + ".json"
+    with open(dirpath / filename, "w", encoding="utf-8") as fp:
         json.dump(data, fp, ensure_ascii=False, indent=2)
 
 


### PR DESCRIPTION
    Path(dirname) / name + '.json'
TypeError: unsupported operand type(s) for +: 'WindowsPath' and 'str'