### PR TITLE
Reparametrize lognormals for ecospold2 imports

### DIFF
--- a/bw2io/importers/ecospold2.py
+++ b/bw2io/importers/ecospold2.py
@@ -53,6 +53,7 @@ class SingleOutputEcospold2Importer(LCIImporter):
         extractor=Ecospold2DataExtractor,
         use_mp=True,
         signal=None,
+        reparametrize_lognormals=False,
     ):
 
         """
@@ -70,6 +71,10 @@ class SingleOutputEcospold2Importer(LCIImporter):
             Flag to indicate whether to use multiprocessing, by default True.
         signal : object
             Object to indicate the status of the import process, by default None.
+        reparametrize_lognormals: bool
+            Flag to indicate if lognormal distributions for exchanges should be reparametrized
+            such that the mean value of the resulting distribution meets the amount
+            defined for the exchange.
         """
         
         self.dirpath = dirpath
@@ -93,12 +98,16 @@ class SingleOutputEcospold2Importer(LCIImporter):
             delete_ghost_exchanges,
             remove_uncertainty_from_negative_loss_exchanges,
             fix_unreasonably_high_lognormal_uncertainties,
-            set_lognormal_loc_value,
             convert_activity_parameters_to_list,
             add_cpc_classification_from_single_reference_product,
             delete_none_synonyms,
             partial(update_social_flows_in_older_consequential, biosphere_db=Database(config.biosphere)),
         ]
+
+        if reparametrize_lognormals:
+            self.strategies.append(reparametrize_lognormal_to_agree_with_static_amount)
+        else:
+            self.strategies.append(set_lognormal_loc_value)
 
         start = time()
         try:

--- a/bw2io/strategies/__init__.py
+++ b/bw2io/strategies/__init__.py
@@ -28,6 +28,7 @@ __all__ = [
     "fix_ecoinvent_flows_pre35",
     "fix_localized_water_flows",
     "fix_unreasonably_high_lognormal_uncertainties",
+    "reparametrize_lognormal_to_agree_with_static_amount",
     "fix_zero_allocation_products",
     "json_ld_add_activity_unit",
     "json_ld_add_products_as_activities",

--- a/tests/strategies/ecospold2.py
+++ b/tests/strategies/ecospold2.py
@@ -112,6 +112,12 @@ def test_reparametrize_lognormal_to_agree_with_static_amount():
                     "amount": 1,
                 },
                 {
+                    "uncertainty type": LognormalUncertainty.id,
+                    "loc": 1000,
+                    "scale": 2,
+                    "amount": -1,
+                },
+                {
                     "uncertainty type": -1,
                     "loc": 1000,
                     "amount": 1,
@@ -127,6 +133,12 @@ def test_reparametrize_lognormal_to_agree_with_static_amount():
                     "loc": -2,
                     "scale": 2,
                     "amount": 1,
+                },
+                {
+                    "uncertainty type": LognormalUncertainty.id,
+                    "loc": -2,
+                    "scale": 2,
+                    "amount": -1,
                 },
                 {
                     "uncertainty type": -1,

--- a/tests/strategies/ecospold2.py
+++ b/tests/strategies/ecospold2.py
@@ -7,6 +7,7 @@ from bw2io.strategies.ecospold2 import (
     fix_unreasonably_high_lognormal_uncertainties,
     remove_uncertainty_from_negative_loss_exchanges,
     set_lognormal_loc_value,
+    reparametrize_lognormal_to_agree_with_static_amount,
 )
 
 
@@ -98,6 +99,44 @@ def test_set_lognormal_loc_value():
         }
     ]
     assert set_lognormal_loc_value(db) == expected
+
+
+def test_reparametrize_lognormal_to_agree_with_static_amount():
+    db = [
+        {
+            "exchanges": [
+                {
+                    "uncertainty type": LognormalUncertainty.id,
+                    "loc": 1000,
+                    "scale": 2,
+                    "amount": 1,
+                },
+                {
+                    "uncertainty type": -1,
+                    "loc": 1000,
+                    "amount": 1,
+                },
+            ]
+        }
+    ]
+    expected = [
+        {
+            "exchanges": [
+                {
+                    "uncertainty type": LognormalUncertainty.id,
+                    "loc": -2,
+                    "scale": 2,
+                    "amount": 1,
+                },
+                {
+                    "uncertainty type": -1,
+                    "loc": 1000,
+                    "amount": 1,
+                },
+            ]
+        }
+    ]
+    assert reparametrize_lognormal_to_agree_with_static_amount(db) == expected
 
 
 def test_remove_uncertainty_from_negative_loss_exchanges():


### PR DESCRIPTION
By the definition of the ecospold2 format, the mean of a lognormal distribution of an exchange is not equal to the amount specified for that exchange, see issue https://github.com/brightway-lca/brightway2-calc/issues/76.

This PR adds a strategy which sets `loc` for lognormal distributions on imported databases such that the expected value (mean) of the resulting distribution is equal to the (static) amount specified for that exchange. More precisely,

$$
\mu = \log a - \frac {\sigma^2} 2
$$

where $a$ is the (static) amount and $\sigma$ is `scale`, i.e., the standard deviation of the underlying normal distribution.

The strategy is *not* applied by default but only if a specific flag (`reparametrize_lognormals=True`) is provided when initializing an instance of `SingleOutputEcospold2Importer`.