### PR TITLE
Move KEYS variable to function header

### DIFF
--- a/bw2io/importers/base_lci.py
+++ b/bw2io/importers/base_lci.py
@@ -397,7 +397,7 @@ class LCIImporter(ImportBase):
         bio = Database(biosphere_name)
 
         def reformat(exc):
-            dct = {key: value for key, value in list(exc.items()) if key in KEYS}
+            dct = {key: value for key, value in list(exc.items()) if key in fields}
             dct.update(
                 type="emission",
                 exchanges=[],

--- a/bw2io/importers/base_lci.py
+++ b/bw2io/importers/base_lci.py
@@ -388,7 +388,7 @@ class LCIImporter(ImportBase):
                 ]
             )
 
-    def add_unlinked_flows_to_biosphere_database(self, biosphere_name=None, KEYS = {"name", "unit", "categories"}):
+    def add_unlinked_flows_to_biosphere_database(self, biosphere_name=None, fields = {"name", "unit", "categories"}):
         biosphere_name = biosphere_name or config.biosphere
         assert biosphere_name in databases, u"{} biosphere database not found".format(
             biosphere_name

--- a/bw2io/importers/base_lci.py
+++ b/bw2io/importers/base_lci.py
@@ -388,15 +388,13 @@ class LCIImporter(ImportBase):
                 ]
             )
 
-    def add_unlinked_flows_to_biosphere_database(self, biosphere_name=None):
+    def add_unlinked_flows_to_biosphere_database(self, biosphere_name=None, KEYS = {"name", "unit", "categories"}):
         biosphere_name = biosphere_name or config.biosphere
         assert biosphere_name in databases, u"{} biosphere database not found".format(
             biosphere_name
         )
 
         bio = Database(biosphere_name)
-
-        KEYS = {"name", "unit", "categories"}
 
         def reformat(exc):
             dct = {key: value for key, value in list(exc.items()) if key in KEYS}


### PR DESCRIPTION
Using the function with a biosphere database where biosphere flows are unique based on parameters 'name', 'categories', 'unit' and 'location' will not work properly, because the variable KEYS is predefined within the function to only include parameters 'name', 'categories' and 'unit'.

Solution: move the KEYS variable from within the function to the function header to be able to have a dynamic input. 
