### PR TITLE
change units before linking

### DIFF
--- a/bw2io/importers/simapro_csv.py
+++ b/bw2io/importers/simapro_csv.py
@@ -72,8 +72,8 @@ class SimaProCSVImporter(LCIImporter):
             functools.partial(migrate_datasets, migration="default-units"),
             functools.partial(migrate_exchanges, migration="default-units"),
             functools.partial(set_code_by_activity_hash, overwrite=True),
-            link_technosphere_based_on_name_unit_location,
             change_electricity_unit_mj_to_kwh,
+            link_technosphere_based_on_name_unit_location,
             set_lognormal_loc_value_uncertainty_safe,
         ]
         if normalize_biosphere:


### PR DESCRIPTION
In Agribalyse, some Electricity activities are in kWh and some others are in MJ.
I get 87 unlinked technosphere activities at the end, some of them are these Electricity activities.

The simapro strategies first link_technosphere_based_on_name_unit_location and then change_electricity_unit_mj_to_kwh.

If I swap these two strategies, I end up with 57 unlinked activities instead of 87. The unlinked Electricity are now linked.
