### PR TITLE
Add-cas-numbers

### DIFF
--- a/bw2io/extractors/ecospold2.py
+++ b/bw2io/extractors/ecospold2.py
@@ -586,6 +586,8 @@ class Ecospold2DataExtractor(object):
             data["chemical formula"] = exc.get("formula")
         if exc.get("mathematicalRelation"):
             data["formula"] = exc.get("mathematicalRelation")
-
+        if exc.get("casNumber"):
+            data["CAS number"] = exc.get("casNumber")
+        
         data.update(cls.extract_uncertainty_dict(exc))
         return data

--- a/bw2io/extractors/ecospold2.py
+++ b/bw2io/extractors/ecospold2.py
@@ -587,7 +587,7 @@ class Ecospold2DataExtractor(object):
         if exc.get("mathematicalRelation"):
             data["formula"] = exc.get("mathematicalRelation")
         if exc.get("casNumber"):
-            data["CAS number"] = exc.get("casNumber")
+            data["CAS number"] = exc.get("casNumber").lstrip("0")
         
         data.update(cls.extract_uncertainty_dict(exc))
         return data


### PR DESCRIPTION
Just an addition of two lines so that the cas numbers from the ecospold files are present in the bw2database.

I have tested this and used it to extract the cas numbers and scrape chemical information and structures. See [the repo here](https://github.com/Stew-McD/brightway-scripts/tree/main/ecoinvent-chemical_structures) for more information