### PR TITLE
Backport fix for "chemical formulas" from 0.9.DEV7 to 0.8.X 

### DIFF
--- a/bw2io/extractors/ecospold2.py
+++ b/bw2io/extractors/ecospold2.py
@@ -246,7 +246,7 @@ class Ecospold2DataExtractor(object):
             "amount": float(obj.get("amount")),
         }
         if obj.get("formula"):
-            data["formula"] = obj.get("formula")
+            data["chemical formula"] = obj.get("formula")
 
         if hasattr(obj, "uncertainty"):
             unc = obj.uncertainty


### PR DESCRIPTION
Fix of #247 

(cherry picked from commit c19d6875c4aa222c17ed5fd5e4918dfffc2f6cf1)