### PR TITLE
don't remove \x7f but convert to newline

### DIFF
--- a/bw2io/extractors/simapro_csv.py
+++ b/bw2io/extractors/simapro_csv.py
@@ -92,7 +92,7 @@ def to_number(obj):
 
 # \x7f if ascii delete - where does it come from?
 strip_whitespace_and_delete = lambda obj: (
-    obj.replace("\x7f", "").strip() if isinstance(obj, str) else obj
+    obj.replace("\x7f", "\n").strip() if isinstance(obj, str) else obj
 )
 
 uppercase_expression = (


### PR DESCRIPTION
The comments in a simapro csv files contain several sentences separated with \x7f
This character is removed during import and the comment are not well separated.
I guess this char can be converted to a newline. This allows to then convert it easily to a `<br/>` in an HTML output.

As an example here is a comment :
```
Comment: Included processes: The inventory includes : undefined Cut-off rule, exclusion : undefined Remark: Functional unit:Produce 268 t of kiwifruits during 19 years on 1 Ha Academic publications and agricultural publications ILCD  Overall data quality : Technological representativeness (TeR) = undefined Geographical representativeness (GR) = undefined
```
There is no wy to separate the elements. By keeping a separator it can then be displayed as :
```
Comment:
Included processes: 
The inventory includes : undefined
Cut-off rule, exclusion : undefined 
Remark: 
Functional unit:Produce 268 t of kiwifruits during 19 years on 1 Ha 
Academic publications and agricultural publications ILCD  
Overall data quality : Technological representativeness (TeR) = undefined 
Geographical representativeness (GR) = undefined
```