### PR TITLE
split up ecoinvent.import_ecoinvent_release into 2 functions

### DIFF
--- a/bw2io/__init__.py
+++ b/bw2io/__init__.py
@@ -29,6 +29,7 @@ __all__ = [
     "get_csv_example_filepath",
     "get_xlsx_example_filepath",
     "import_ecoinvent_release",
+    "import_ecoinvent_biosphere",
     "install_project",
     "lci_matrices_to_excel",
     "lci_matrices_to_matlab",
@@ -98,7 +99,7 @@ from .unlinked_data import UnlinkedData, unlinked_data
 from .utils import activity_hash, es2_activity_hash, load_json_data_file
 
 try:
-    from .ecoinvent import import_ecoinvent_release
+    from .ecoinvent import import_ecoinvent_release, import_ecoinvent_biosphere
 except ImportError:
     import warnings
 

--- a/bw2io/ecoinvent.py
+++ b/bw2io/ecoinvent.py
@@ -176,6 +176,7 @@ def import_ecoinvent_release(
     if not len(migrations):
         create_core_migrations()
 
+    # Setup ecoinvent interface
     if username is None and password is None:
         settings = ei.Settings()
     else:
@@ -183,6 +184,7 @@ def import_ecoinvent_release(
     if not settings.username or not settings.password:
         raise ValueError("Can't determine ecoinvent username or password")
 
+    # Validate version and system model
     release = ei.EcoinventRelease(settings)
     if version not in release.list_versions():
         raise ValueError(f"Invalid version {version}")
@@ -192,6 +194,7 @@ def import_ecoinvent_release(
     if system_model not in release.list_system_models(version):
         raise ValueError(f"Invalid system model {system_model}")
 
+    # Set up biosphere database name
     if biosphere_name is None:
         biosphere_name = f"ecoinvent-{version}-biosphere"
     if biosphere_write_mode not in ("patch", "replace"):
@@ -200,7 +203,18 @@ def import_ecoinvent_release(
             + f" got `{biosphere_write_mode}`"
         )
         raise ValueError(error)
+
     if lci:
+        # Import biosphere first
+        _import_biosphere(
+            version=version,
+            system_model=system_model,
+            biosphere_name=biosphere_name,
+            biosphere_write_mode=biosphere_write_mode,
+            release=release,
+        )
+
+        # Then technosphere
         lci_path = release.get_release(
             version=version,
             system_model=system_model,
@@ -210,35 +224,6 @@ def import_ecoinvent_release(
         db_name = f"ecoinvent-{version}-{system_model}"
         if db_name in bd.databases:
             raise ValueError(f"Database {db_name} already exists")
-
-        eb = Ecospold2BiosphereImporter(
-            name=biosphere_name,
-            filepath=lci_path / "MasterData" / "ElementaryExchanges.xml",
-        )
-        eb.apply_strategies()
-        if not eb.all_linked:
-            raise ValueError(
-                f"Can't ingest biosphere database {biosphere_name} - unlinked flows."
-            )
-
-        if biosphere_name not in bd.databases or biosphere_write_mode == "replace":
-            eb.write_database(overwrite=False)
-        else:
-            existing = {flow["code"] for flow in bd.Database(biosphere_name)}
-            new = [flow for flow in eb.data if flow["code"] not in existing]
-            if new:
-                new_list = "\n\t".join(
-                    ["{}: {}".format(o["name"], o["categories"]) for o in new]
-                )
-                print(
-                    f"Adding {len(new)} biosphere flows to {biosphere_name}:\n\t{new_list}"
-                )
-                for flow in new:
-                    if "database" in flow:
-                        del flow["database"]
-                    bd.Database(biosphere_name).new_activity(**flow).save()
-
-        bd.preferences["biosphere_database"] = biosphere_name
 
         soup = SingleOutputEcospold2Importer(
             dirpath=lci_path / "datasets",
@@ -254,146 +239,268 @@ def import_ecoinvent_release(
         soup.write_database()
 
     if lcia:
-        subversion = int(version.split(".")[1])
-        if subversion < 4:
-            raise ValueError("LCIA import for versions 3.0-3.3 not supported")
+        # Import LCIA methods
+        _import_lcia(
+            version=version,
+            biosphere_name=biosphere_name or bd.config.biosphere,
+            namespace_lcia_methods=namespace_lcia_methods,
+            release=release,
+        )
 
-        if biosphere_name is None:
-            biosphere_name = bd.config.biosphere
-        if biosphere_name not in bd.databases or not len(bd.Database(biosphere_name)):
-            raise ValueError(
-                f"Can't find populated biosphere flow database {biosphere_name}"
+
+def import_ecoinvent_biosphere(
+    version: str,
+    system_model: str = "cutoff",
+    username: Optional[str] = None,
+    password: Optional[str] = None,
+    biosphere_name: Optional[str] = None,
+    biosphere_write_mode: str = "patch",
+) -> None:
+    """
+    Import only the biosphere flows from an ecoinvent release.
+
+    Parameters
+    ----------
+    version : str
+        The ecoinvent release version, e.g. '3.9.1'
+    system_model : str
+        The system model in short or long form, e.g. 'cutoff'
+    username : Optional[str]
+        ecoinvent username
+    password : Optional[str]
+        ecoinvent password
+    biosphere_name : Optional[str]
+        Name for biosphere database
+    biosphere_write_mode : str
+        How to handle existing database ('patch' or 'replace')
+    """
+    # Setup ecoinvent interface
+    if username is None and password is None:
+        settings = ei.Settings()
+    else:
+        settings = ei.Settings(username=username, password=password)
+    if not settings.username or not settings.password:
+        raise ValueError("Can't determine ecoinvent username or password")
+
+    # Validate version and system model
+    release = ei.EcoinventRelease(settings)
+    if version not in release.list_versions():
+        raise ValueError(f"Invalid version {version}")
+
+    if system_model in SYSTEM_MODELS:
+        system_model = SYSTEM_MODELS[system_model]
+    if system_model not in release.list_system_models(version):
+        raise ValueError(f"Invalid system model {system_model}")
+
+    # Set up biosphere database name
+    if biosphere_name is None:
+        biosphere_name = f"ecoinvent-{version}-biosphere"
+    if biosphere_write_mode not in ("patch", "replace"):
+        error = (
+            "`biosphere_write_mode` must be either `patch` or `replace`;"
+            + f" got `{biosphere_write_mode}`"
+        )
+        raise ValueError(error)
+
+    _import_biosphere(
+        version=version,
+        system_model=system_model,
+        biosphere_name=biosphere_name,
+        biosphere_write_mode=biosphere_write_mode,
+        release=release,
+    )
+
+
+def _import_biosphere(
+    version: str,
+    system_model: str,
+    biosphere_name: str,
+    biosphere_write_mode: str,
+    release: ei.EcoinventRelease,
+) -> None:
+    """Import only biosphere flows from ecoinvent release."""
+    lci_path = release.get_release(
+        version=version,
+        system_model=system_model,
+        release_type=ei.ReleaseType.ecospold,
+    )
+
+    eb = Ecospold2BiosphereImporter(
+        name=biosphere_name,
+        filepath=lci_path / "MasterData" / "ElementaryExchanges.xml",
+    )
+    eb.apply_strategies()
+    if not eb.all_linked:
+        raise ValueError(
+            f"Can't ingest biosphere database {biosphere_name} - unlinked flows."
+        )
+
+    if biosphere_name not in bd.databases or biosphere_write_mode == "replace":
+        eb.write_database()
+    else:
+        existing = {flow["code"] for flow in bd.Database(biosphere_name)}
+        new = [flow for flow in eb.data if flow["code"] not in existing]
+        if new:
+            new_list = "\n\t".join(
+                ["{}: {}".format(o["name"], o["categories"]) for o in new]
             )
-
-        lcia_file = ei.get_excel_lcia_file_for_version(release=release, version=version)
-        sheet_names = get_excel_sheet_names(lcia_file)
-
-        if "units" in sheet_names:
-            units_sheetname = "units"
-        elif "Indicators" in sheet_names:
-            units_sheetname = "Indicators"
-        else:
-            raise ValueError(
-                f"Can't find worksheet for impact category units in {sheet_names}"
+            print(
+                f"Adding {len(new)} biosphere flows to {biosphere_name}:\n\t{new_list}"
             )
+            for flow in new:
+                if "database" in flow:
+                    del flow["database"]
+                bd.Database(biosphere_name).new_activity(**flow).save()
 
-        if "CFs" not in sheet_names:
-            raise ValueError(
-                f"Can't find worksheet for characterization factors; expected `CFs`, found {sheet_names}"
-            )
+    bd.preferences["biosphere_database"] = biosphere_name
 
-        data = dict(ExcelExtractor.extract(lcia_file))
-        units = header_dict(data[units_sheetname])
 
-        cfs = header_dict(data["CFs"])
+def _import_lcia(
+    version: str,
+    biosphere_name: str,
+    namespace_lcia_methods: bool,
+    release: ei.EcoinventRelease,
+) -> None:
+    """Import only LCIA methods from ecoinvent release."""
+    subversion = int(version.split(".")[1])
+    if subversion < 4:
+        raise ValueError("LCIA import for versions 3.0-3.3 not supported")
 
-        CF_COLUMN_LABELS = {
-            "3.4": "cf 3.4",
-            "3.5": "cf 3.5",
-            "3.6": "cf 3.6",
+    if biosphere_name not in bd.databases or not len(bd.Database(biosphere_name)):
+        raise ValueError(
+            f"Can't find populated biosphere flow database {biosphere_name}"
+        )
+
+    lcia_file = ei.get_excel_lcia_file_for_version(release=release, version=version)
+    sheet_names = get_excel_sheet_names(lcia_file)
+
+    if "units" in sheet_names:
+        units_sheetname = "units"
+    elif "Indicators" in sheet_names:
+        units_sheetname = "Indicators"
+    else:
+        raise ValueError(
+            f"Can't find worksheet for impact category units in {sheet_names}"
+        )
+
+    if "CFs" not in sheet_names:
+        raise ValueError(
+            f"Can't find worksheet for characterization factors; expected `CFs`, found {sheet_names}"
+        )
+
+    data = dict(ExcelExtractor.extract(lcia_file))
+    units = header_dict(data[units_sheetname])
+    cfs = header_dict(data["CFs"])
+
+    CF_COLUMN_LABELS = {
+        "3.4": "cf 3.4",
+        "3.5": "cf 3.5",
+        "3.6": "cf 3.6",
+    }
+    cf_col_label = CF_COLUMN_LABELS.get(version, "cf")
+    units_col_label = pick_a_unit_label_already(units[0])
+
+    if namespace_lcia_methods:
+        units_mapping = {
+            (
+                f"ecoinvent-{version}",
+                row["method"],
+                row["category"],
+                row["indicator"],
+            ): row[units_col_label]
+            for row in units
         }
-        cf_col_label = CF_COLUMN_LABELS.get(version, "cf")
-        units_col_label = pick_a_unit_label_already(units[0])
+    else:
+        units_mapping = {
+            (row["method"], row["category"], row["indicator"]): row[units_col_label]
+            for row in units
+        }
+
+    biosphere_mapping = {}
+    for flow in bd.Database(biosphere_name):
+        biosphere_mapping[(flow["name"],) + tuple(flow["categories"])] = flow.id
+        if flow["name"].startswith("[Deleted]"):
+            biosphere_mapping[
+                (flow["name"].replace("[Deleted]", ""),) + tuple(flow["categories"])
+            ] = flow.id
+
+    lcia_data_as_dict = defaultdict(list)
+    unmatched = set()
+    substituted = set()
+
+    for row in cfs:
         if namespace_lcia_methods:
-            units_mapping = {
-                (
-                    f"ecoinvent-{version}",
-                    row["method"],
-                    row["category"],
-                    row["indicator"],
-                ): row[units_col_label]
-                for row in units
-            }
+            impact_category = (
+                f"ecoinvent-{version}",
+                row["method"],
+                row["category"],
+                row["indicator"],
+            )
         else:
-            units_mapping = {
-                (row["method"], row["category"], row["indicator"]): row[units_col_label]
-                for row in units
-            }
+            impact_category = (row["method"], row["category"], row["indicator"])
 
-        biosphere_mapping = {}
-        for flow in bd.Database(biosphere_name):
-            biosphere_mapping[(flow["name"],) + tuple(flow["categories"])] = flow.id
-            if flow["name"].startswith("[Deleted]"):
-                biosphere_mapping[
-                    (flow["name"].replace("[Deleted]", ""),) + tuple(flow["categories"])
-                ] = flow.id
+        if row[cf_col_label] is None:
+            continue
 
-        lcia_data_as_dict = defaultdict(list)
-
-        unmatched = set()
-        substituted = set()
-
-        for row in cfs:
-            if namespace_lcia_methods:
-                impact_category = (
-                    f"ecoinvent-{version}",
-                    row["method"],
-                    row["category"],
-                    row["indicator"],
+        try:
+            lcia_data_as_dict[impact_category].append(
+                (
+                    biosphere_mapping[
+                        drop_unspecified(
+                            row["name"], row["compartment"], row["subcompartment"]
+                        )
+                    ],
+                    float(row[cf_col_label]),
                 )
-            else:
-                impact_category = (row["method"], row["category"], row["indicator"])
-            if row[cf_col_label] is None:
-                continue
-            try:
+            )
+        except KeyError:
+            # How is this possible? We are matching ecoinvent data against
+            # ecoinvent data from the same release! And yet it moves...
+            category = (
+                (row["compartment"], row["subcompartment"])
+                if row["subcompartment"].lower() != "unspecified"
+                else (row["compartment"],)
+            )
+            same_context = {
+                k[0]: v for k, v in biosphere_mapping.items() if k[1:] == category
+            }
+            candidates = sorted(
+                [
+                    (damerau_levenshtein(name, row["name"]), name)
+                    for name in same_context
+                ]
+            )
+            if (
+                candidates[0][0] < 3
+                and candidates[0][0] != candidates[1][0]
+                and candidates[0][1][0].lower() == row["name"][0].lower()
+            ):
+                new_name = candidates[0][1]
+                pair = (new_name, row["name"])
+                if pair not in substituted:
+                    print(f"Substituting {new_name} for {row['name']}")
+                    substituted.add(pair)
                 lcia_data_as_dict[impact_category].append(
                     (
-                        biosphere_mapping[
-                            drop_unspecified(
-                                row["name"], row["compartment"], row["subcompartment"]
-                            )
-                        ],
+                        same_context[new_name],
                         float(row[cf_col_label]),
                     )
                 )
-            except KeyError:
-                # How is this possible? We are matching ecoinvent data against
-                # ecoinvent data from the same release! And yet it moves...
-                category = (
-                    (row["compartment"], row["subcompartment"])
-                    if row["subcompartment"].lower() != "unspecified"
-                    else (row["compartment"],)
-                )
-                same_context = {
-                    k[0]: v for k, v in biosphere_mapping.items() if k[1:] == category
-                }
-                candidates = sorted(
-                    [
-                        (damerau_levenshtein(name, row["name"]), name)
-                        for name in same_context
-                    ]
-                )
-                if (
-                    candidates[0][0] < 3
-                    and candidates[0][0] != candidates[1][0]
-                    and candidates[0][1][0].lower() == row["name"][0].lower()
-                ):
-                    new_name = candidates[0][1]
-                    pair = (new_name, row["name"])
-                    if pair not in substituted:
-                        print(f"Substituting {new_name} for {row['name']}")
-                        substituted.add(pair)
-                    lcia_data_as_dict[impact_category].append(
-                        (
-                            same_context[new_name],
-                            float(row[cf_col_label]),
+            else:
+                if row["name"] not in unmatched:
+                    print(
+                        "Skipping unmatched flow {}:({}, {})".format(
+                            row["name"], row["compartment"], row["subcompartment"]
                         )
                     )
-                else:
-                    if row["name"] not in unmatched:
-                        print(
-                            "Skipping unmatched flow {}:({}, {})".format(
-                                row["name"], row["compartment"], row["subcompartment"]
-                            )
-                        )
-                        unmatched.add(row["name"])
+                    unmatched.add(row["name"])
 
-        for key in lcia_data_as_dict:
-            method = bd.Method(key)
-            method.register(
-                unit=units_mapping.get(key, "Unknown"),
-                filepath=str(lcia_file),
-                ecoinvent_version=version,
-                database=biosphere_name,
-            )
-            method.write(lcia_data_as_dict[key])
+    for key in lcia_data_as_dict:
+        method = bd.Method(key)
+        method.register(
+            unit=units_mapping.get(key, "Unknown"),
+            filepath=str(lcia_file),
+            ecoinvent_version=version,
+            database=biosphere_name,
+        )
+        method.write(lcia_data_as_dict[key])

--- a/tests/new_ecoinvent.py
+++ b/tests/new_ecoinvent.py
@@ -1,0 +1,136 @@
+import bw2data as bd
+import bw2io as bi
+
+# bd.projects.set_current("testX1")
+# bi.import_ecoinvent_release(
+#     version="3.9.1",
+#     system_model="cutoff",
+# )
+# print(bd.databases)
+# print(bd.Database("ecoinvent-3.9.1-cutoff").random().lca(bd.methods.random()).score)
+# print(len(bd.Database("ecoinvent-3.9.1-cutoff")))
+# print(len(bd.Database("ecoinvent-3.9.1-biosphere")))
+
+
+# output
+'''
+Applying strategy: normalize_units
+Applying strategy: drop_unspecified_subcategories
+Applying strategy: ensure_categories_are_tuples
+Applied 3 strategies in 0.00 seconds
+4718 datasets
+        0 exchanges
+        Links to the following databases:
+
+        0 unlinked exchanges (0 types)
+
+100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 4718/4718 [00:00<00:00, 23494.63it/s]
+18:09:57 [info     ] Vacuuming database            
+Created database: ecoinvent-3.9.1-biosphere
+Extracting XML data from 21238 datasets
+Extracted 21238 datasets in 49.66 seconds
+Applying strategy: normalize_units
+Applying strategy: update_ecoinvent_locations
+Applying strategy: remove_zero_amount_coproducts
+Applying strategy: remove_zero_amount_inputs_with_no_activity
+Applying strategy: remove_unnamed_parameters
+Applying strategy: es2_assign_only_product_with_amount_as_reference_product
+Applying strategy: assign_single_product_as_activity
+Applying strategy: create_composite_code
+Applying strategy: drop_unspecified_subcategories
+Applying strategy: fix_ecoinvent_flows_pre35
+Applying strategy: drop_temporary_outdated_biosphere_flows
+Applying strategy: link_biosphere_by_flow_uuid
+Applying strategy: link_internal_technosphere_by_composite_code
+Applying strategy: delete_exchanges_missing_activity
+Applying strategy: delete_ghost_exchanges
+Applying strategy: remove_uncertainty_from_negative_loss_exchanges
+Applying strategy: fix_unreasonably_high_lognormal_uncertainties
+Applying strategy: convert_activity_parameters_to_list
+Applying strategy: add_cpc_classification_from_single_reference_product
+Applying strategy: delete_none_synonyms
+Applying strategy: update_social_flows_in_older_consequential
+Applying strategy: set_lognormal_loc_value
+Applied 22 strategies in 7.22 seconds
+21238 datasets
+        674593 exchanges
+        Links to the following databases:
+                ecoinvent-3.9.1-biosphere (407351 exchanges)
+                ecoinvent-3.9.1-cutoff (267242 exchanges)
+        0 unlinked exchanges (0 types)
+
+18:11:05 [warning  ] Not able to determine geocollections for all datasets. This database is not ready for regionalization.
+100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 21238/21238 [00:35<00:00, 591.84it/s]
+18:11:41 [info     ] Vacuuming database            
+Created database: ecoinvent-3.9.1-cutoff
+Databases dictionary with 2 object(s):
+        ecoinvent-3.9.1-biosphere
+        ecoinvent-3.9.1-cutoff
+/home/marsh/miniforge3/envs/bionly/lib/python3.11/site-packages/bw2calc/__init__.py:47: UserWarning: 
+It seems like you have an AMD/INTEL x64 architecture, but haven't installed pypardiso:
+
+    https://pypi.org/project/pypardiso/
+
+Installing it could give you much faster calculations.
+
+  warnings.warn(PYPARDISO_WARNING)
+0.00018292772209895243
+21238
+4718
+'''
+
+# biosphere only
+# bd.projects.set_current("testX2")
+# bi.import_ecoinvent_biosphere("3.9.1")
+# print(bd.databases)
+# print(len(bd.Database("ecoinvent-3.9.1-biosphere")))
+
+# output
+'''
+Applying strategy: normalize_units
+Applying strategy: drop_unspecified_subcategories
+Applying strategy: ensure_categories_are_tuples
+Applied 3 strategies in 0.00 seconds
+4718 datasets
+        0 exchanges
+        Links to the following databases:
+
+        0 unlinked exchanges (0 types)
+
+100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 4718/4718 [00:00<00:00, 19210.42it/s]
+18:17:02 [info     ] Vacuuming database            
+Created database: ecoinvent-3.9.1-biosphere
+Databases dictionary with 1 object(s):
+        ecoinvent-3.9.1-biosphere
+4718
+'''
+
+# adding lcia
+bd.projects.set_current("testX2")
+bi.import_ecoinvent_release(
+    version="3.9.1",
+    system_model="cutoff",
+    lci=False,
+    lcia=True,
+)
+
+print(bd.databases)
+print(bd.methods)
+
+# output
+'''
+Databases dictionary with 1 object(s):
+        ecoinvent-3.9.1-biosphere
+Methods dictionary with 762 objects, including:
+        ('ecoinvent-3.9.1', 'CML v4.8 2016', 'acidification', 'acidification (incl. fate, average Europe total, A&B)')
+        ('ecoinvent-3.9.1', 'CML v4.8 2016', 'climate change', 'global warming potential (GWP100)')
+        ('ecoinvent-3.9.1', 'CML v4.8 2016', 'ecotoxicity: freshwater', 'freshwater aquatic ecotoxicity (FAETP inf)')
+        ('ecoinvent-3.9.1', 'CML v4.8 2016', 'ecotoxicity: marine', 'marine aquatic ecotoxicity (MAETP inf)')
+        ('ecoinvent-3.9.1', 'CML v4.8 2016', 'ecotoxicity: terrestrial', 'terrestrial ecotoxicity (TETP inf)')
+        ('ecoinvent-3.9.1', 'CML v4.8 2016', 'energy resources: non-renewable', 'abiotic depletion potential (ADP): fossil fuels')
+        ('ecoinvent-3.9.1', 'CML v4.8 2016', 'eutrophication', 'eutrophication (fate not incl.)')
+        ('ecoinvent-3.9.1', 'CML v4.8 2016', 'human toxicity', 'human toxicity (HTP inf)')
+        ('ecoinvent-3.9.1', 'CML v4.8 2016', 'material resources: metals/minerals', 'abiotic depletion potential (ADP): elements (ultimate reserves)')
+        ('ecoinvent-3.9.1', 'CML v4.8 2016', 'ozone depletion', 'ozone layer depletion (ODP steady state)')
+Use `list(this object)` to get the complete list.
+'''


### PR DESCRIPTION
I often need just to import biosphere or/and lcia by itself. The current ecoinvent function first is too big second doesn't allow me to do that. So i did not make a lot of changes its just splitting up the one big function ('import_ecoinvent_release') into '_import_biosphere' and '_import_lcia'. Plus adding the separate function 'import_ecoinvent_biosphere' that just imports biosphere.

So now you have three options:
1- import_ecoinvent_release(lci=False) --> just lcia
2- import_ecoinvent_biosphere --> just biosphere
3- import_ecoinvent_release --> all (functions as it was before)

This also doesn't break any workflows.