### PR TITLE
bw2parameters CapitalizationError during simapro strategy

### DIFF
--- a/bw2io/strategies/simapro.py
+++ b/bw2io/strategies/simapro.py
@@ -215,6 +215,9 @@ def sp_allocate_products(db):
                         ds["parameters"] = {
                             k.lower(): v for k, v in ds["parameters"].items()
                         }
+                        for k in ds["parameters"].keys():
+                            if "formula" in ds["parameters"][k]:
+                                ds["parameters"][k]["formula"] = ds["parameters"][k]["formula"].lower()
                         interp = bw2parameters.ParameterSet(
                             ds["parameters"]
                         ).get_interpreter()


### PR DESCRIPTION
During an import of a wool activity:
```
### Applying strategies...
Applying strategy: normalize_units
Applying strategy: update_ecoinvent_locations
Applying strategy: assign_only_product_as_production
Applying strategy: drop_unspecified_subcategories
Applying strategy: sp_allocate_products
Traceback (most recent call last):
  File "/home/jovyan/ecobalyse/data/import_ecoinvent.py", line 61, in <module>
    main()
  File "/home/jovyan/ecobalyse/data/import_ecoinvent.py", line 50, in main
    import_simapro_csv(
  File "/home/jovyan/ecobalyse/data/common/import_.py", line 236, in import_simapro_csv
    database.apply_strategies()
  File "/opt/conda/lib/python3.11/site-packages/bw2io/importers/base.py", line 126, in apply_strategies
    self.apply_strategy(func, verbose)
  File "/opt/conda/lib/python3.11/site-packages/bw2io/importers/base.py", line 92, in apply_strategy
    self.data = strategy(self.data)
                ^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.11/site-packages/bw2io/strategies/simapro.py", line 110, in sp_allocate_products
    interp = bw2parameters.ParameterSet(
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.11/site-packages/bw2parameters/parameter_set.py", line 34, in __init__
    self.order = self.get_order()
                 ^^^^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.11/site-packages/bw2parameters/parameter_set.py", line 60, in get_order
    raise CapitalizationError(
bw2parameters.errors.CapitalizationError: Possible errors in upper/lower case letters for some parameters.
Unmatched references:
{ 'lamb_alloc': {'LAMB_SALES', 'TOTAL_SALES'},
  'total_sales': {'LAMB_SALES', 'WOOL_SALES'},
  'wool_alloc': {'TOTAL_SALES', 'WOOL_SALES'}}
Matched references:
[ 'ArithmeticError',
  'AssertionError',
  'AttributeError',
(...)
  'kron',
  'lamb_sales',
  'ldexp',
(...)
  'wool_sales',
  'zeros',
  'zeros_like',
  'zip']
```

Here is the end of the csv file with allocation parameters:
```
(...)
Products  
"wool; sheep; production mix; at farm; 1 kg greasy wool";kg;368555353,9;Wool_alloc;not defined;Agricultural\Animal feed\Market\Infrastructure;;;
"liveweight; sheep; production mix; at farm; 1 kg liveweight";kg;1525734513;Lamb_alloc;not defined;Agricultural\Animal feed\Market\Infrastructure;;;

(...)

Input parameters
Diesel_L_to_kg;0,85;Undefined;1;0;0;No;;
Petrol_L_to_kg;0,75;Undefined;1;0;0;No;;
Lamb_sales;4739988494;Undefined;1;0;0;No;($)^?;
Wool_sales;2820255119;Undefined;1;0;0;No;($)^?;

Calculated parameters
Total_sales;Lamb_sales + Wool_sales;($)^?;;;;;;
Lamb_alloc;Lamb_sales / Total_sales * 100;(%)^?;;;;;;
Wool_alloc;Wool_sales / Total_sales * 100;(%)^?;;;;;;

End
```

Not 100% sure of the right fix, as I don"t understand the need for lowering/uppering case on the parameters.