### PR TITLE
Fix: handle string version in get_projects (fixes #326)

### DIFF
--- a/bw2io/remote.py
+++ b/bw2io/remote.py
@@ -31,7 +31,8 @@ def get_projects(
     base_url: Optional[str] = None,
     filename: Optional[str] = None,
 ) -> dict:
-    BW2 = bd.__version__ < (4,)
+    version_tuple = tuple(map(int, bd.__version__.split('.')))
+    BW2 = version_tuple < (4,)
     projects = PROJECTS_BW2 if BW2 else PROJECTS_BW25
     if base_url is None:
         base_url = "https://files.brightway.dev/"

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -1,0 +1,66 @@
+import pytest
+import bw2data as bd
+from bw2io import remote
+
+
+# What requests.get(...).json() should return.
+PROJECTS = {
+    'ecoinvent-3.8-biosphere': 'ecoinvent-3.8-biosphere.tar.gz',
+    'ecoinvent-3.9.1-biosphere': 'ecoinvent-3.9.1-biosphere.tar.gz',
+    'USEEIO-1.1': 'USEEIO-1.1.tar.gz',
+    'forwast': 'forwast.tar.gz',
+    'ecoinvent-3.10-biosphere': 'ecoinvent-3.10-biosphere.tar.gz',
+    'regionalization-example': 'regionalization-example.tar.gz',
+    'spatiotemporal-example': 'spatiotemporal-example.tar.gz',
+    'multifunctional-demo': 'multifunctional-demo.tar.gz'
+}
+
+
+def test_get_projects_handles_string_version(mocker, monkeypatch):
+    """
+    Test for fix of issue: https://github.com/brightway-lca/brightway2-io/issues/326
+
+    Test that get_projects:
+    1. Correctly parses the bd.__version__ string.
+    2. Calls the correct URL based on the version.
+    3. Returns the updated dictionary.
+    """
+    
+    # Mock the base project constants as empty dicts.
+    mocker.patch("bw2io.remote.PROJECTS_BW2", {})
+    mocker.patch("bw2io.remote.PROJECTS_BW25", {})
+
+    # Create a mock for the 'requests.get' response object
+    mock_response = mocker.Mock()
+    # Configure it to return the real data you provided
+    mock_response.json.return_value = PROJECTS
+    
+    # Patch 'requests.get' inside the bw2io.remote module
+    mock_get_patch = mocker.patch(
+        "bw2io.remote.requests.get", 
+        return_value=mock_response
+    )
+
+    # Test with version string "3.9.1" (< 4)
+    # This should trigger the BW2 (v3) logic
+    monkeypatch.setattr(bd, "__version__", "3.9.1")
+    
+    projects = remote.get_projects(update_config=True)
+    
+    # Assertions for v3
+    assert projects == PROJECTS
+    mock_get_patch.assert_called_with(
+        "https://files.brightway.dev/projects-config.bw2.json"
+    )
+
+    # Test with version string "4.0.1" (>= 4)
+    # This should trigger the BW25 (v4) logic
+    monkeypatch.setattr(bd, "__version__", "4.0.1")
+
+    projects = remote.get_projects(update_config=True)
+    
+    # Assertions for v4
+    assert projects == PROJECTS
+    mock_get_patch.assert_called_with(
+        "https://files.brightway.dev/projects-config.json"
+    )


### PR DESCRIPTION
## Description
This PR fixes a `TypeError` in `remote.get_projects` that occurs when `bd.__version__` is a string (e.g. `"X.X"`) instead of a tuple. The original code attempted to compare the version string directly to a tuple (`< (4,)`), causing a crash.

The fix converts `bd.__version__` to a tuple of integers before performing the version comparison, ensuring it works correctly regardless of the `bw2data` version format.

## Related Issue
Fixes #326 from user [mrvisscher](https://github.com/mrvisscher)
I had the same issue today morning so I hope I can help you with this quick fix

## Type of Change
- Bug fix (non-breaking change which fixes an issue)

## Testing
I have added a new test file `tests/test_remote.py` which:
1.  Mocks the `requests.get`. I have not changed anything in this section so this was just some mock data simulating with 'pytest-mock'.
2.  Mocks two constants to verify the differences in BW2 else PROJECTS_BW25.
3.  **The actual important part**: Verifies that the function correctly handles both v3-style (e.g. `"3.9.1"`) and v4-style (e.g. `"4.0.1"`) version strings without raising a `TypeError`.

The test cases pass locally with these changes.
