### PR TITLE
fix: parse bd.__version__ safely

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # `bw2io` Changelog
 
+## 0.9.12 (2025-12-16)
+
+* Fix #293. version parsing for remote.install parses bd.__version__ correctly.
+
 ## 0.9.11 (2025-06-23)
 
 * [#316: Add ability to separate ecoSpold2 products and processes when importing](https://github.com/brightway-lca/brightway2-io/pull/316)

--- a/bw2io/__init__.py
+++ b/bw2io/__init__.py
@@ -47,7 +47,7 @@ __all__ = [
     "useeio20",
 ]
 
-__version__ = "0.9.11"
+__version__ = "0.9.12"
 
 from .backup import (
     backup_data_directory,

--- a/bw2io/remote.py
+++ b/bw2io/remote.py
@@ -1,6 +1,5 @@
-from packaging.version import parse
+from packaging.version import parse as vparse
 from pathlib import Path
-import requests
 from typing import Optional, Union
 from urllib.parse import urljoin
 
@@ -22,34 +21,43 @@ PROJECTS_BW25 = {
     "forwast": "forwast.tar.gz",
 }
 
+BASE_URL = "https://files.brightway.dev/"
+
 cache_dir = Path(bd.projects._base_data_dir) / "bw2io_cache_dir"
 cache_dir.mkdir(exist_ok=True)
 
+def _projects_config_filename(version) -> str:
+    """Return the config filename given a bd.__version__ (str or tuple)."""
+    # Normalize tuple -> string
+    if isinstance(version, tuple):
+        version = ".".join(map(str, version))
+    return "projects-config.json" if vparse(str(version)) >= vparse("4") else "projects-config.bw2.json"
 
-def get_projects(
-    update_config: bool = True,
-    base_url: Optional[str] = None,
-    filename: Optional[str] = None,
-) -> dict:
+
+def _fetch_projects_config(base_url: str, filename: str) -> dict:
+    """Indirection point for I/O (easy to mock in tests)."""
+    import requests  # local import so tests don’t even need requests if they patch this
+    try:
+        response = requests.get(urljoin(base_url, filename), timeout=10)
+        response.raise_for_status()
+        return response.json()
+    except requests.exceptions.RequestException as exc:
+        print(f"Can't connect to {base_url}: {exc}")
+    except ValueError as exc:
+        # JSON decoding error
+        print(f"Invalid JSON received from {base_url}: {exc}")
+
+
+def get_projects(update_config: bool = True, base_url: str = BASE_URL) -> dict:
     bd_version = bd.__version__
     if not isinstance(bd_version, str):
         bd_version = ".".join(map(str, bd_version))
-    BW2 = parse(bd_version) < parse("4")
+    BW2 = vparse(bd_version) < vparse("4")
     projects = PROJECTS_BW2 if BW2 else PROJECTS_BW25
-    if base_url is None:
-        base_url = "https://files.brightway.dev/"
-    if filename is None:
-        filename = "projects-config.bw2.json" if BW2 else "projects-config.json"
     if update_config:
-        try:
-            response = requests.get(urljoin(base_url, filename), timeout=10)
-            response.raise_for_status()
-            projects.update(response.json())
-        except requests.exceptions.RequestException as exc:
-            print(f"Can't connect to {base_url}: {exc}")
-        except ValueError as exc:
-            # JSON decoding error
-            print(f"Invalid JSON received from {base_url}: {exc}")
+        filename = _projects_config_filename(getattr(bd, "__version__", "0"))
+        projects.update(_fetch_projects_config(base_url, filename))
+
     return projects
 
 
@@ -57,7 +65,7 @@ def install_project(
     project_key: str,
     project_name: Optional[str] = None,
     projects_config: Optional[dict] = None,
-    url: Optional[str] = "https://files.brightway.dev/",
+    url: Optional[str] = BASE_URL,
     overwrite_existing: Optional[bool] = False,
     __recursive: Union[bool, None] = False,
 ):
@@ -92,7 +100,7 @@ def install_project(
     try:
         filename = projects_config[project_key]
     except KeyError:
-        raise KeyError(f"Project key {project_key} not in `project_config`")
+        raise KeyError(f"Project key {project_key} not in `projects_config`")
 
     fp = cache_dir / filename
     if not fp.exists():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,7 @@ testing = [
     "bw2io",
     "pytest",
     "pytest-cov",
+    "pytest-mock",
     "python-coveralls"
 ]
 dev = [

--- a/tests/remote/test_remote.py
+++ b/tests/remote/test_remote.py
@@ -1,0 +1,66 @@
+import pytest
+import bw2data as bd
+from bw2io import remote
+
+
+# What requests.get(...).json() should return.
+PROJECTS = {
+    'ecoinvent-3.8-biosphere': 'ecoinvent-3.8-biosphere.tar.gz',
+    'ecoinvent-3.9.1-biosphere': 'ecoinvent-3.9.1-biosphere.tar.gz',
+    'USEEIO-1.1': 'USEEIO-1.1.tar.gz',
+    'forwast': 'forwast.tar.gz',
+    'ecoinvent-3.10-biosphere': 'ecoinvent-3.10-biosphere.tar.gz',
+    'regionalization-example': 'regionalization-example.tar.gz',
+    'spatiotemporal-example': 'spatiotemporal-example.tar.gz',
+    'multifunctional-demo': 'multifunctional-demo.tar.gz'
+}
+
+
+def test_get_projects_handles_string_version(mocker, monkeypatch):
+    """
+    Test for fix of issue: https://github.com/brightway-lca/brightway2-io/issues/326
+
+    Test that get_projects:
+    1. Correctly parses the bd.__version__ string.
+    2. Calls the correct URL based on the version.
+    3. Returns the updated dictionary.
+    """
+    
+    # Mock the base project constants as empty dicts.
+    mocker.patch("bw2io.remote.PROJECTS_BW2", {})
+    mocker.patch("bw2io.remote.PROJECTS_BW25", {})
+
+    # Create a mock for the 'requests.get' response object
+    mock_response = mocker.Mock()
+    # Configure it to return the real data you provided
+    mock_response.json.return_value = PROJECTS
+    
+    # Patch 'requests.get' inside the bw2io.remote module
+    mock_get_patch = mocker.patch(
+        "bw2io.remote.requests.get", 
+        return_value=mock_response
+    )
+
+    # Test with version string "3.9.1" (< 4)
+    # This should trigger the BW2 (v3) logic
+    monkeypatch.setattr(bd, "__version__", "3.9.1")
+    
+    projects = remote.get_projects(update_config=True)
+    
+    # Assertions for v3
+    assert projects == PROJECTS
+    mock_get_patch.assert_called_with(
+        "https://files.brightway.dev/projects-config.bw2.json", timeout=10
+    )
+
+    # Test with version string "4.0.1" (>= 4)
+    # This should trigger the BW25 (v4) logic
+    monkeypatch.setattr(bd, "__version__", "4.0.1")
+
+    projects = remote.get_projects(update_config=True)
+    
+    # Assertions for v4
+    assert projects == PROJECTS
+    mock_get_patch.assert_called_with(
+        "https://files.brightway.dev/projects-config.json", timeout=10
+    )

--- a/tests/remote/test_remote.py
+++ b/tests/remote/test_remote.py
@@ -1,66 +1,47 @@
 import pytest
 import bw2data as bd
-from bw2io import remote
+import bw2io as bi
 
-
-# What requests.get(...).json() should return.
 PROJECTS = {
-    'ecoinvent-3.8-biosphere': 'ecoinvent-3.8-biosphere.tar.gz',
-    'ecoinvent-3.9.1-biosphere': 'ecoinvent-3.9.1-biosphere.tar.gz',
-    'USEEIO-1.1': 'USEEIO-1.1.tar.gz',
-    'forwast': 'forwast.tar.gz',
-    'ecoinvent-3.10-biosphere': 'ecoinvent-3.10-biosphere.tar.gz',
-    'regionalization-example': 'regionalization-example.tar.gz',
-    'spatiotemporal-example': 'spatiotemporal-example.tar.gz',
-    'multifunctional-demo': 'multifunctional-demo.tar.gz'
+    "ecoinvent-3.8-biosphere": "ecoinvent-3.8-biosphere.tar.gz",
+    "ecoinvent-3.9.1-biosphere": "ecoinvent-3.9.1-biosphere.tar.gz",
+    "USEEIO-1.1": "USEEIO-1.1.tar.gz",
+    "forwast": "forwast.tar.gz",
+    "ecoinvent-3.10-biosphere": "ecoinvent-3.10-biosphere.tar.gz",
+    "regionalization-example": "regionalization-example.tar.gz",
+    "spatiotemporal-example": "spatiotemporal-example.tar.gz",
+    "multifunctional-demo": "multifunctional-demo.tar.gz",
 }
 
+@pytest.mark.parametrize(
+    "version, expected_filename",
+    [
+        ("3.9.1", "projects-config.bw2.json"),
+        ((3, 9, 1), "projects-config.bw2.json"),
+        ("4.0.1", "projects-config.json"),
+        ((4, 0, 0), "projects-config.json"),
+    ],
+)
+def test_get_projects_pure_unit_no_requests(monkeypatch, version, expected_filename):
+    # Avoid any dependence on module constants
+    monkeypatch.setattr(bi.remote, "PROJECTS_BW2", {})
+    monkeypatch.setattr(bi.remote, "PROJECTS_BW25", {})
 
-def test_get_projects_handles_string_version(mocker, monkeypatch):
-    """
-    Test for fix of issue: https://github.com/brightway-lca/brightway2-io/issues/326
+    # Set version as str or tuple
+    monkeypatch.setattr(bd, "__version__", version)
 
-    Test that get_projects:
-    1. Correctly parses the bd.__version__ string.
-    2. Calls the correct URL based on the version.
-    3. Returns the updated dictionary.
-    """
-    
-    # Mock the base project constants as empty dicts.
-    mocker.patch("bw2io.remote.PROJECTS_BW2", {})
-    mocker.patch("bw2io.remote.PROJECTS_BW25", {})
+    # Capture what get_projects *would* fetch, but don’t do I/O
+    seen = {}
+    def fake_fetch(base_url, filename):
+        seen["base_url"] = base_url
+        seen["filename"] = filename
+        return PROJECTS
 
-    # Create a mock for the 'requests.get' response object
-    mock_response = mocker.Mock()
-    # Configure it to return the real data you provided
-    mock_response.json.return_value = PROJECTS
-    
-    # Patch 'requests.get' inside the bw2io.remote module
-    mock_get_patch = mocker.patch(
-        "bw2io.remote.requests.get", 
-        return_value=mock_response
-    )
+    monkeypatch.setattr(bi.remote, "_fetch_projects_config", fake_fetch)
 
-    # Test with version string "3.9.1" (< 4)
-    # This should trigger the BW2 (v3) logic
-    monkeypatch.setattr(bd, "__version__", "3.9.1")
-    
-    projects = remote.get_projects(update_config=True)
-    
-    # Assertions for v3
+    projects = bi.remote.get_projects(update_config=True, base_url="https://files.brightway.dev/")
+
     assert projects == PROJECTS
-    mock_get_patch.assert_called_with(
-        "https://files.brightway.dev/projects-config.bw2.json", timeout=10
-    )
+    assert seen["base_url"] == "https://files.brightway.dev/"
+    assert seen["filename"] == expected_filename
 
-    # Test with version string "4.0.1" (>= 4)
-    # This should trigger the BW25 (v4) logic
-    monkeypatch.setattr(bd, "__version__", "4.0.1")
-
-    projects = remote.get_projects(update_config=True)
-    
-    # Assertions for v4
-    assert projects == PROJECTS
-    mock_get_patch.assert_called_with(
-        "https://files.brightway.dev/projects-config.json", timeout=10
-    )


### PR DESCRIPTION
Before, the version of bd was parsed to determine if the remote projects to download should be bw2 or bw25 compatible.
With this commit, the version parsing is defensively parsed as either str or tuple.

see #329 