### PR TITLE
Trigger CI on PR commits by adding synchronize event type

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -19,7 +19,7 @@ on:
       - ".gitignore"
   pull_request:
     branches: [main]
-    types: [opened, reopened] # excludes syncronize to avoid redundant trigger from commits on PRs
+    types: [opened, reopened, synchronize]
     paths-ignore:
       - "**.md"
       - "**.bib"


### PR DESCRIPTION
## Summary

- Adds `synchronize` to the `pull_request` event types in the CI workflow
- Previously, CI only ran on PR `opened` and `reopened` events, so commits pushed to an existing PR never triggered a test run

## Test plan

- Open a PR and push a follow-up commit — CI should now trigger on both the initial open and the subsequent push