### PR TITLE
Fix test_categories_as_list failing with peewee.OperationalError

### DIFF
--- a/tests/strategies/lcia.py
+++ b/tests/strategies/lcia.py
@@ -409,6 +409,26 @@ class LCIATestCase2(BW2DataTest):
         ]
         self.assertEqual(expected, match_subcategories(data, "b"))
 
+    def test_categories_as_list(self):
+        """issues/212 - categories given as list instead of tuple should not raise"""
+        data = [
+            {
+                "name": "Method 1",
+                "exchanges": [
+                    {
+                        "categories": [
+                            "air",
+                        ],
+                        "name": "Emission",
+                        "unit": "kg",
+                        "amount": 1.0,
+                    },
+                ],
+            }
+        ]
+        biosphere_db_name = "example_biosphere"
+        match_subcategories(data, biosphere_db_name)  # should pass without traceback
+
     def test_match_subcategories_makes_copies(self):
         """Should copy data instead of creating references, so that there are different amounts for different methods."""
         self.maxDiff = None
@@ -457,27 +477,6 @@ class LCIATestCase2(BW2DataTest):
             self.assertEqual(cf["amount"], 1)
         for cf in result[1]["exchanges"]:
             self.assertEqual(cf["amount"], 2)
-
-
-def test_categories_as_list():
-    """issues/212"""
-    data = [
-        {
-            "name": "Method 1",
-            "exchanges": [
-                {
-                    "categories": [
-                        "air",
-                    ],
-                    "name": "Emission",
-                    "unit": "kg",
-                    "amount": 1.0,
-                },
-            ],
-        }
-    ]
-    biosphere_db_name = "example_biosphere"
-    match_subcategories(data, biosphere_db_name)  # should pass without traceback
 
 
 def test_rationalize_method_names_no_remove_lt():


### PR DESCRIPTION
## Summary

- `test_categories_as_list` (issue #212) was a standalone pytest function with no bw2data project set up
- `match_subcategories` internally calls `Database(biosphere_db_name)`, which requires an active bw2data project to locate its SQLite file
- Without a project, peewee raised `OperationalError: unable to open database file`

## Fix

Moved `test_categories_as_list` into `LCIATestCase2`, which extends `BW2DataTest` and provides proper project setup/teardown via a temporary directory. Since `"example_biosphere"` is not registered in the temp project, the `Database` loop yields no flows — which is correct, as the test only asserts that passing a `list` for `categories` does not raise.

## Test plan

- [ ] `pytest tests/strategies/lcia.py::LCIATestCase2::test_categories_as_list` passes
- [ ] `pytest tests/strategies/lcia.py` — all 16 tests pass