### PR TITLE
Reduce CI test matrix to Python 3.9, 3.11, and 3.14

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -41,7 +41,7 @@ jobs:
              macos-14,
              ubuntu-22.04,
              windows-2022]
-        py-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        py-version: ["3.9", "3.11", "3.14"]
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
## Summary

- Reduces the Python version matrix from 6 versions (3.9, 3.10, 3.11, 3.12, 3.13, 3.14) to 3 versions (3.9, 3.11, 3.14)
- Cuts CI job count in half, covering oldest supported, a middle LTS, and the latest version