### PR TITLE
Release 0.9.15

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,14 @@
 # `bw2io` Changelog
 
+## 0.9.15 (2026-04-16)
+
+* [#335: Cache extracted Ecospold files + adds progress bar on parallel import](https://github.com/brightway-lca/brightway2-io/pull/335). Thanks @raphaeljolivet.
+* [#336: Adjust `ExcelImporter` documentation for clarification](https://github.com/brightway-lca/brightway2-io/pull/336). Thanks @nicolnt.
+* [#338: Read temporal distributions from Excel model](https://github.com/brightway-lca/brightway2-io/pull/338). Thanks @jakobsarthur.
+* [#340: Fix import from bw2-generated packages](https://github.com/brightway-lca/brightway2-io/pull/340)
+* [#341: Fix `test_categories_as_list` failing with `peewee.OperationalError`](https://github.com/brightway-lca/brightway2-io/pull/341)
+* [#343: Fix `test_restore_project` `PermissionError` on Windows](https://github.com/brightway-lca/brightway2-io/pull/343)
+
 ## 0.9.14 (2026-01-13)
 
 * Remove `normalize_biosphere_categories` and `normalize_biosphere_names`  from default strategies. These are specific to the ecoinvent 2-3 transition, and therefore not appropriate for generic IO tasks. They can still be applied manually if needed.

--- a/bw2io/__init__.py
+++ b/bw2io/__init__.py
@@ -47,7 +47,7 @@ __all__ = [
     "useeio20",
 ]
 
-__version__ = "0.9.14"
+__version__ = "0.9.15"
 
 from .backup import (
     backup_data_directory,


### PR DESCRIPTION
## Summary

- Bump version to `0.9.15`
- Update `CHANGES.md` with entries for all changes since `0.9.14`

## Changes included

- [#335](https://github.com/brightway-lca/brightway2-io/pull/335): Cache extracted Ecospold files + progress bar on parallel import (@raphaeljolivet)
- [#336](https://github.com/brightway-lca/brightway2-io/pull/336): `ExcelImporter` documentation clarification (@nicolnt)
- [#338](https://github.com/brightway-lca/brightway2-io/pull/338): Read temporal distributions from Excel model (@jakobsarthur)
- [#340](https://github.com/brightway-lca/brightway2-io/pull/340): Fix import from bw2-generated packages
- [#341](https://github.com/brightway-lca/brightway2-io/pull/341): Fix `test_categories_as_list` with `peewee.OperationalError`
- [#343](https://github.com/brightway-lca/brightway2-io/pull/343): Fix `test_restore_project` `PermissionError` on Windows

## Test plan

- [ ] CI passes on this branch
- [ ] Version resolves correctly: `python -c "import bw2io; print(bw2io.__version__)"`