### PR TITLE
Release 0.9.16

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # `bw2io` Changelog
 
+## 0.9.16 (2026-04-24)
+
+* [#345: Add `collapse_comments` option and extract `includedActivities` fields from ecospold2](https://github.com/brightway-lca/brightway2-io/pull/345)
+
 ## 0.9.15 (2026-04-16)
 
 * [#335: Cache extracted Ecospold files + adds progress bar on parallel import](https://github.com/brightway-lca/brightway2-io/pull/335). Thanks @raphaeljolivet.

--- a/bw2io/__init__.py
+++ b/bw2io/__init__.py
@@ -47,7 +47,7 @@ __all__ = [
     "useeio20",
 ]
 
-__version__ = "0.9.15"
+__version__ = "0.9.16"
 
 from .backup import (
     backup_data_directory,


### PR DESCRIPTION
## Summary

- Adds changelog entry for [#345](https://github.com/brightway-lca/brightway2-io/pull/345) (new `collapse_comments` option and `includedActivities` field extraction from ecospold2)
- Bumps version to `0.9.16`