### PR TITLE
feat: extract samplingProcedure and extrapolations when collapse_comments=False

### DIFF
--- a/bw2io/extractors/ecospold2.py
+++ b/bw2io/extractors/ecospold2.py
@@ -333,6 +333,14 @@ class Ecospold2DataExtractor(object):
             if time_comment:
                 comment["time period"] = time_comment
 
+        try:
+            repr_obj = stem.modellingAndValidation.representativeness
+            modeling_summary = _text(getattr2(repr_obj, "samplingProcedure")) or None
+            data_handling_summary = _text(getattr2(repr_obj, "extrapolations")) or None
+        except AttributeError:
+            modeling_summary = None
+            data_handling_summary = None
+
         classifications = [
             (el.classificationSystem.text, el.classificationValue.text)
             for el in stem.activityDescription.iterchildren()
@@ -392,6 +400,10 @@ class Ecospold2DataExtractor(object):
             },
             "type": "process",
         }
+
+        if not collapse_comments:
+            data["modeling_summary"] = modeling_summary
+            data["data_handling_summary"] = data_handling_summary
 
         if cache_file:
             with gzip.open(cache_file, "wt") as f:

--- a/tests/ecospold2/ecospold2_extractor.py
+++ b/tests/ecospold2/ecospold2_extractor.py
@@ -392,3 +392,18 @@ def test_collapse_comments_false():
     assert comment["technology"] == "typical technology for ze Germans!"
     assert "geography" not in comment
     assert "time period" not in comment
+    assert data[0]["modeling_summary"] == "Literature"
+    assert data[0]["data_handling_summary"] == (
+        "This dataset has been extrapolated from year 2001 to the year of the"
+        " calculation (2018). The uncertainty has been adjusted accordingly."
+    )
+
+
+def test_collapse_comments_true_omits_repr_fields():
+    data = Ecospold2DataExtractor.extract(
+        FIXTURES / SPOLD,
+        "ei",
+        collapse_comments=True,
+    )
+    assert "modeling_summary" not in data[0]
+    assert "data_handling_summary" not in data[0]


### PR DESCRIPTION
## Summary

- When `collapse_comments=False`, `Ecospold2DataExtractor.extract_activity` now returns two additional keys:
  - `modeling_summary` ← `modellingAndValidation/representativeness/samplingProcedure`
  - `data_handling_summary` ← `modellingAndValidation/representativeness/extrapolations`
- Both are `None` when the element is absent or empty.
- These keys are **not present** when `collapse_comments=True`, preserving backwards compatibility.

## Test plan

- [ ] `test_collapse_comments_false` extended to assert both new keys have the expected text from the existing fixture (which already had `samplingProcedure` and `extrapolations`)
- [ ] `test_collapse_comments_true_omits_repr_fields` added to confirm keys are absent in default mode
- [ ] All 10 ecospold2 extractor tests pass