### PR TITLE
Release 0.9.17

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # `bw2io` Changelog
 
+## 0.9.17 (2026-04-26)
+
+* Extract `samplingProcedure` (as `modeling_summary`) and `extrapolations` (as `data_handling_summary`) from ecospold2 when `collapse_comments=False`
+
 ## 0.9.16 (2026-04-24)
 
 * [#345: Add `collapse_comments` option and extract `includedActivities` fields from ecospold2](https://github.com/brightway-lca/brightway2-io/pull/345)

--- a/bw2io/__init__.py
+++ b/bw2io/__init__.py
@@ -47,7 +47,7 @@ __all__ = [
     "useeio20",
 ]
 
-__version__ = "0.9.16"
+__version__ = "0.9.17"
 
 from .backup import (
     backup_data_directory,

--- a/bw2io/extractors/ecospold2.py
+++ b/bw2io/extractors/ecospold2.py
@@ -333,6 +333,14 @@ class Ecospold2DataExtractor(object):
             if time_comment:
                 comment["time period"] = time_comment
 
+        try:
+            repr_obj = stem.modellingAndValidation.representativeness
+            modeling_summary = _text(getattr2(repr_obj, "samplingProcedure")) or None
+            data_handling_summary = _text(getattr2(repr_obj, "extrapolations")) or None
+        except AttributeError:
+            modeling_summary = None
+            data_handling_summary = None
+
         classifications = [
             (el.classificationSystem.text, el.classificationValue.text)
             for el in stem.activityDescription.iterchildren()
@@ -392,6 +400,10 @@ class Ecospold2DataExtractor(object):
             },
             "type": "process",
         }
+
+        if not collapse_comments:
+            data["modeling_summary"] = modeling_summary
+            data["data_handling_summary"] = data_handling_summary
 
         if cache_file:
             with gzip.open(cache_file, "wt") as f:

--- a/tests/ecospold2/ecospold2_extractor.py
+++ b/tests/ecospold2/ecospold2_extractor.py
@@ -392,3 +392,18 @@ def test_collapse_comments_false():
     assert comment["technology"] == "typical technology for ze Germans!"
     assert "geography" not in comment
     assert "time period" not in comment
+    assert data[0]["modeling_summary"] == "Literature"
+    assert data[0]["data_handling_summary"] == (
+        "This dataset has been extrapolated from year 2001 to the year of the"
+        " calculation (2018). The uncertainty has been adjusted accordingly."
+    )
+
+
+def test_collapse_comments_true_omits_repr_fields():
+    data = Ecospold2DataExtractor.extract(
+        FIXTURES / SPOLD,
+        "ei",
+        collapse_comments=True,
+    )
+    assert "modeling_summary" not in data[0]
+    assert "data_handling_summary" not in data[0]


### PR DESCRIPTION
## Summary

- Extract `samplingProcedure` (as `modeling_summary`) and `extrapolations` (as `data_handling_summary`) from ecospold2 `modellingAndValidation/representativeness` when `collapse_comments=False`
- These fields are absent when `collapse_comments=True`, preserving backwards compatibility
- Bump version to 0.9.17 and update changelog

## Test plan

- [ ] Existing tests pass
- [ ] New tests in `tests/ecospold2/ecospold2_extractor.py` cover the extracted fields